### PR TITLE
More idiomatic Elvish, and fix a bug (no "command" command)

### DIFF
--- a/.elvish/lib/chain.elv
+++ b/.elvish/lib/chain.elv
@@ -6,15 +6,14 @@
 #   edit:rprompt=chain:rprompt
 
 # Initialize glyphs to be used in the prompt.
-prompt_glyph=">"
-git_branch_glyph="⎇"
-git_dirty_glyph="±"
-chain_su_glyph="⚡"
+prompt_glyph = ">"
+git_branch_glyph = "⎇"
+git_dirty_glyph = "±"
+chain_su_glyph = "⚡"
 
-fn prompt_segment {
-   color @rest = $@args
-   text = "["(echo $@rest)"]-"
-   edit:styled $text $color
+fn prompt_segment [style @texts]{
+   text = "["(joins ' ' $texts)"]-"
+   edit:styled $text $style
 }
 
 fn is_git_repo {
@@ -23,19 +22,19 @@ fn is_git_repo {
 
 fn git_branch_name {
    if (is_git_repo) {
-     echo (git symbolic-ref HEAD 2>/dev/null | sed -e "s|^refs/heads/||")
+     git symbolic-ref HEAD 2>/dev/null | sed -e "s|^refs/heads/||"
    } else {
      echo ""
    }
 }
 
 fn is_git_dirty {
-   put (and (is_git_repo) (not (eq "" (command git status -s --ignore-submodules=dirty 2>/dev/null))))
+   and (is_git_repo) (not (eq "" (git status -s --ignore-submodules=dirty 2>/dev/null)))
 }
 
 fn prompt_root {
-   uid=(id -u $E:USER)
-   if (eq (id -u $E:USER) 0) {
+   uid = (id -u)
+   if (eq $uid 0) {
      prompt_segment yellow $chain_su_glyph
    } else {
      put ""
@@ -72,10 +71,10 @@ fn prompt_arrow {
 # end
 
 fn prompt {
-   chain:prompt_root
-   chain:prompt_dir
-   chain:prompt_git
-   chain:prompt_arrow
+   prompt_root
+   prompt_dir
+   prompt_git
+   prompt_arrow
 }
 
 fn rprompt {


### PR DESCRIPTION
Hi! Thanks for this. I tried to improve a little bit to be more idiomatic Elvish -- for which I have an unfair edge because I haven't documented what is idomatic Elvish :)

* Use the spacey form of assignments (`a = b`). I am thinking about making the tight form (`a=b`) only do temporary assignment, so a lone `a=b` will be a syntax error.

* Forms like `echo (xxx)` or `put (xxx)` are almost always equivalent to just `xxx`.

* There is no `command` command in Elvish. If you want to be sure you are calling an external command, use `e:` (e.g. `e:git`). However, that is almost never necessary, because functions are also lexically scoped; if `git` is defined as function in another module or `rc.elv`, it won't affect your use of `git`.

* Since functions are lexically scoped, when you are referring to functions in the same namespace (`chain` here), drop the namespace (`chain:`).

  Right now namespace imports are global: that is, if you `use chain` in any file (in this case, `rc.elv`), you have access to the `chain:` namespace not just in `rc.elv`, but elsewhere as well. I am also considering making namespace imports lexically scoped, so if will be an error to use `chain:xxx` here.